### PR TITLE
Add rainbow DLs option

### DIFF
--- a/src/game/rendering_graph_node.c
+++ b/src/game/rendering_graph_node.c
@@ -181,6 +181,8 @@ void mtx_patch_interpolated(void) {
     sViewportPos = NULL;
 }
 
+bool rainbow = false;
+
 /**
  * Process a master list node.
  */
@@ -223,6 +225,10 @@ static void geo_process_master_list_sub(struct GraphNodeMasterList *node) {
     if (enableZBuffer != 0) {
         gDPPipeSync(gDisplayListHead++);
         gSPClearGeometryMode(gDisplayListHead++, G_ZBUFFER);
+    }
+
+    if (rainbow) {
+        gSPClearGeometryMode(gDisplayListHead++, G_LIGHTING);
     }
 }
 

--- a/src/saturn/imgui/saturn_imgui_machinima.cpp
+++ b/src/saturn/imgui/saturn_imgui_machinima.cpp
@@ -354,6 +354,7 @@ void imgui_machinima_quick_options() {
             // Erase existing timelines
             k_frame_keys.clear();
         }
+
         for (int i = 0; i < 6; i++) {
             ImGui::SameLine();
             if (ImGui::Button((std::string(enabled_acts[i] ? ICON_FK_STAR : ICON_FK_STAR_O) + "###act_select_" + std::to_string(i)).c_str())) {
@@ -361,6 +362,13 @@ void imgui_machinima_quick_options() {
             }
             imgui_bundled_tooltip((std::string(enabled_acts[i] ? "Disable" : "Enable") + " act " + std::to_string(i + 1) + " objects").c_str());
         }
+
+        extern bool rainbow;
+
+        ImGui::Separator();
+        ImGui::Checkbox("Rainbow DisplayLists", &rainbow);
+        imgui_bundled_tooltip("Sets the displaylists to be Rainbow.");
+        saturn_keyframe_popout("k_r_dls");
 
         /*auto locations = saturn_get_locations();
         bool do_save = false;


### PR DESCRIPTION
Adds a new option to the Machinima->Options tab. makes the DisplayLists display as rainbow. like the effect in chaos edition mario. only works in chroma key stage for now.
![Screenshot 2024-08-11 214406](https://github.com/user-attachments/assets/a1d3dd24-a025-4ce7-8331-a22f179c07a6)
